### PR TITLE
change effect to 'none' as default, fix typos, and switch off effect …

### DIFF
--- a/31_PLAYBULB.pm
+++ b/31_PLAYBULB.pm
@@ -37,7 +37,7 @@ use Blocking;
 use SetExtensions;
 
 
-my $version = "1.0.1";
+my $version = "1.0.2";
 
 
 
@@ -133,7 +133,7 @@ sub PLAYBULB_Define($$) {
     $attr{$name}{devStateIcon}  = "unreachable:light_question" if( !defined($attr{$name}{devStateIcon}) );
     $attr{$name}{webCmd}        = "rgb:rgb FF0000:rgb 00FF00:rgb 0000FF:rgb FFFFFF:rgb F7FF00:rgb 00FFFF:rgb F700FF:effect" if( !defined($attr{$name}{webCmd}) );
     
-    $hash->{helper}{effect}     = ReadingsVal($name,"effect","Candle"); 
+    $hash->{helper}{effect}     = ReadingsVal($name,"effect","none"); 
     $hash->{helper}{onoff}      = ReadingsVal($name,"onoff",0); 
     $hash->{helper}{rgb}        = ReadingsVal($name,"rgb","ff0000"); 
     $hash->{helper}{sat}        = ReadingsVal($name,"sat",0); 
@@ -263,7 +263,7 @@ sub PLAYBULB_Run($$$) {
     my $effect      =   $hash->{helper}{effect};
     my $speed       =   sprintf("%02x", $hash->{helper}{speed});
     my $stateOnoff  =   $hash->{helper}{onoff};
-    my $stateEffect =   ReadingsVal($name,"effect","Candle");
+    my $stateEffect =   ReadingsVal($name,"effect","none");
     my $ac          =   $playbulbModels{$attr{$name}{model}}{aColor};
     my $ae          =   $playbulbModels{$attr{$name}{model}}{aEffect};
     my $ab          =   $playbulbModels{$attr{$name}{model}}{aBattery};
@@ -384,10 +384,11 @@ sub PLAYBULB_gattCharWrite($$$$$$$$$) {
     
     
     
-    $speed = "01" if( $effect eq "candle" );
+    $speed = "01" if( $effect eq "Candle" );
     
     if( $stateOnoff == 0 ) {
         qx(gatttool -b $mac --char-write -a $ac -n 00000000);
+        qx(gatttool -b $mac --char-write -a $ae -n 00000000ff000000);
     } else {
         qx(gatttool -b $mac --char-write -a $ac -n ${sat}${rgb}) if( $stateEffect eq "none" and $effect eq "none" );
         qx(gatttool -b $mac --char-write -a $ae -n ${sat}${rgb}${effects{$effect}}00${speed}00) if( $stateEffect ne "none" or $effect ne "none" );
@@ -523,7 +524,7 @@ sub PLAYBULB_BlockingDone($) {
     
     delete($hash->{helper}{RUNNING_PID});
     
-    Log3 $name, 3, "(Sub PLAYBULB_Done - $name) - Der Helper ist diabled. Daher wird hier abgebrochen" if($hash->{helper}{DISABLED});
+    Log3 $name, 3, "(Sub PLAYBULB_Done - $name) - Der Helper ist disabled. Daher wird hier abgebrochen" if($hash->{helper}{DISABLED});
     return if($hash->{helper}{DISABLED});
     
     


### PR DESCRIPTION
…on 'off' (required by some older Playbulb Smart)

Some changes to make my playbulb smart usable.

Unfortunately, your current version appears broken - it crashes FHEM when setting the model.